### PR TITLE
Handle Observables that are empty but take a while to complete

### DIFF
--- a/etc/qa/psalm.xml
+++ b/etc/qa/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config ../../vendor/vimeo/psalm/config.xsd"

--- a/tests/AwaitObservableTest.php
+++ b/tests/AwaitObservableTest.php
@@ -180,4 +180,25 @@ final class AwaitObservableTest extends AsyncTestCase
             return $count;
         })()));
     }
+
+    /**
+     * @test
+     */
+    public function emptyObservableThatTookAWhileToComplete(): void
+    {
+        $observable = new Subject();
+        $iterator   = new AwaitingIterator($observable);
+
+        Loop::addTimer(0.1, static function () use ($observable): void {
+            $observable->onCompleted();
+        });
+
+        self::assertTrue($this->await(async(static function () use ($iterator): bool {
+            foreach ($iterator as $void) {
+                return false;
+            }
+
+            return true;
+        })()));
+    }
 }


### PR DESCRIPTION
This situation occurs for example when a database query returns an observable that contains nothing because the result set is empty.